### PR TITLE
Update identify_evdev.py

### DIFF
--- a/identify_evdev.py
+++ b/identify_evdev.py
@@ -28,7 +28,7 @@ def list_active_evdev():
         r,w,x = select.select(devices, [], [])
         for fd in r:
             for event in list(devices[fd].read())[:1]:
-                output.append(devices[fd].fn)
+                output.append(devices[fd].path)
                 anyInput = True
 
     return output


### PR DESCRIPTION
I stumbled upon https://aweirdimagination.net/2015/04/06/emulating-xbox-controllers-on-linux/ which led me to https://aweirdimagination.net/2015/04/04/identifying-joystick-devices/ and then here.

On python 3.10 you'll get a depreciation warning.
```python
identify_evdev.py:31: DeprecationWarning: Please use InputDevice.path instead of InputDevice.fn
  output.append(devices[fd].fn)
/dev/input/event259.
``` 
 It will still work but the output is borked.

With `path` instead:
```zsh
/dev/input/event259
```